### PR TITLE
Version 0.5-SNAPSHOT of the runtime is not available anymore.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>io.kaitai</groupId>
             <artifactId>kaitai-struct-runtime</artifactId>
-            <version>0.5-SNAPSHOT</version>
+            <version>0.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.kaitai</groupId>


### PR DESCRIPTION
This needs to be updated from time to time.

https://oss.sonatype.org/content/repositories/snapshots/io/kaitai/kaitai-struct-runtime/