### PR TITLE
Add support for parameters in types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,6 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: |
+        mvn install:install-file -Dfile=lib/HexLib.jar -DgroupId=at.HexLib -DartifactId=HexLib -Dversion=0.0.0 -Dpackaging=jar -DlocalRepositoryPath=./lib
+        mvn -B package --file pom.xml


### PR DESCRIPTION
Even `ksv` has no such feature (see https://github.com/kaitai-io/kaitai_struct_visualizer/issues/33). Now you can look at parameterized types somehow:

![parameters](https://user-images.githubusercontent.com/450131/72224536-66db3100-359d-11ea-9d7d-f8104d534070.png)

Based on #6, so can be merged instead of #6.