### PR TITLE
Replace HEX viewer library by JHexView

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '7.x', '8.x', '9.x', '10.x', '11.x', '12.x', '13.x' ]
+        java: [ '8.x', '9.x', '10.x', '11.x', '12.x', '13.x' ]
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK ${{ matrix.java }}
@@ -15,6 +15,4 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
     - name: Build with Maven
-      run: |
-        mvn install:install-file -Dfile=lib/HexLib.jar -DgroupId=at.HexLib -DartifactId=HexLib -Dversion=0.0.0 -Dpackaging=jar -DlocalRepositoryPath=./lib
-        mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -28,28 +28,10 @@ access to it in a nice, easy-to-comprehend API.
 ## Build
 Install java, maven and, if on windows, git-bash
 
-First, install dependencies into local maven repository:
-
-```bash
-mvn install:install-file -Dfile=lib/HexLib.jar -DgroupId=at.HexLib -DartifactId=HexLib -Dversion=0.0.0 -Dpackaging=jar -DlocalRepositoryPath=./lib
-```
-
-Then build project as usual:
+Run in console:
 
 ```bash
 mvn install
-```
-
-If you got error:
-```bash
-[WARNING] The POM for kaitai_struct_visualizer_java:HexLib:jar:0.0.0 is missing, no dependency information available
-```
-it means, that you already tried to build project without success and maven cache
-unsuccessful state of dependency resolution. Just add switch `-U` to maven invocation
-to force maven re-check dependencies:
-
-```bash
-$ mvn -U install
 ```
 
 ## Licensing
@@ -77,4 +59,4 @@ Vis tool depends on the following libraries:
 * [kaitai_struct_compiler](https://github.com/kaitai_struct_compiler) — GPLv3+ license
   * [fastparse](http://www.lihaoyi.com/fastparse/) — MIT license
   * [snakeyaml](https://bitbucket.org/asomov/snakeyaml) — Apache 2.0 license
-* [HexLib](http://hexedit-lib.sourceforge.net/) — FreeBSD license
+* [JHexView](https://github.com/Mingun/JHexView) — LGPL-2.1 license

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
       <version>0.8</version>
     </dependency>
     <dependency>
-      <groupId>at.HexLib</groupId>
-      <artifactId>HexLib</artifactId>
-      <version>0.0.0</version>
+      <groupId>ru.mingun</groupId>
+      <artifactId>JHexView</artifactId>
+      <version>2.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.olivergondza</groupId>
@@ -63,8 +63,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -112,8 +112,10 @@
       </snapshots>
     </repository>
     <repository>
-      <id>local-jars</id>
-      <url>file://${project.basedir}/lib</url>
+      <!--JHexView-->
+      <id>bintray-mingun-maven</id>
+      <name>bintray</name>
+      <url>https://dl.bintray.com/mingun/maven</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
[JHexView](https://github.com/Mingun/JHexView) -- GPL 2.0, available at [Bintray](https://bintray.com/mingun/maven/JHexView/1.1) and actively developed by me if new features or bug fixes will required.

That library is more powfull than HexLib, but right now not all abilities is used (but I plan to use it in the future, for example, color maps to colorize different fields by different colors).

Required java version bumped to 1.8, because JHexView use 1.8 as target java version.

Compare:

![New Hex Editor](https://user-images.githubusercontent.com/450131/73612677-9f57b300-460f-11ea-9e98-bad3958227f3.png)

