### PR TITLE
Select hex editor bytes when an instance in an array is selected

### DIFF
--- a/src/main/java/io/kaitai/struct/visualizer/DataNode.java
+++ b/src/main/java/io/kaitai/struct/visualizer/DataNode.java
@@ -26,6 +26,10 @@ public class DataNode extends DefaultMutableTreeNode {
         this(depth, value, null, name, null, null);
     }
 
+    private DataNode(int depth, Object value, String name, Integer posStart, Integer posEnd) {
+        this(depth, value, null, name, posStart, posEnd);
+    }
+
     private DataNode(int depth, Object value, Method method, Integer posStart, Integer posEnd) {
         this(depth, value, method, null, posStart, posEnd);
     }
@@ -134,7 +138,16 @@ public class DataNode extends DefaultMutableTreeNode {
                         Object el = list.get(i);
                         String arrayIdxStr = String.format("%04d", i);
 
-                        children.add(new DataNode(depth + 1, el, arrayIdxStr));
+                        DataNode parentNode = (DataNode) parent;
+                        if (parentNode.value instanceof KaitaiStruct) {
+                            KaitaiStruct parentKaitaiStruct = (KaitaiStruct) parentNode.value;
+                            DebugAids debug = DebugAids.fromStruct(parentKaitaiStruct);
+                            Integer posStart = debug.getArrayStart(name, i);
+                            Integer posEnd = debug.getArrayEnd(name, i);
+                            children.add(new DataNode(depth + 1, el, arrayIdxStr, posStart, posEnd));
+                        } else {
+                            children.add(new DataNode(depth + 1, el, arrayIdxStr));
+                        }
                     }
                 } else if (value instanceof KaitaiStruct) {
                     DebugAids debug = DebugAids.fromStruct((KaitaiStruct) value);
@@ -155,8 +168,8 @@ public class DataNode extends DefaultMutableTreeNode {
                             field.setAccessible(true);
                             Object curValue = field.get(value);
 
-                            Integer posStart = debug.getStart(methodName);
-                            Integer posEnd = debug.getEnd(methodName);
+                            Integer posStart = debug.getAttrStart(methodName);
+                            Integer posEnd = debug.getAttrEnd(methodName);
 
                             DataNode dn = new DataNode(depth + 1, curValue, m, posStart, posEnd);
                             children.add(dn);

--- a/src/main/java/io/kaitai/struct/visualizer/DebugAids.java
+++ b/src/main/java/io/kaitai/struct/visualizer/DebugAids.java
@@ -24,21 +24,21 @@ public class DebugAids {
         this.arrEnd = arrEnd;
     }
 
-    public Integer getStart(String attrName) {
+    public Integer getAttrStart(String attrName) {
         return attrStart.get(attrName);
     }
 
-    public Integer getEnd(String attrName) {
+    public Integer getAttrEnd(String attrName) {
         return attrEnd.get(attrName);
     }
 
-    public Integer getStart(String attrName, int idx) {
-        ArrayList<Integer> positions = arrStart.get(attrName);
+    public Integer getArrayStart(String arrName, int idx) {
+        ArrayList<Integer> positions = arrStart.get(arrName);
         return (positions != null) ? positions.get(idx) : null;
     }
 
-    public Integer getEnd(String attrName, int idx) {
-        ArrayList<Integer> positions = arrEnd.get(attrName);
+    public Integer getArrayEnd(String arrName, int idx) {
+        ArrayList<Integer> positions = arrEnd.get(arrName);
         return (positions != null) ? positions.get(idx) : null;
     }
 


### PR DESCRIPTION
Example KSY file:
```
meta:
  id: array_selection_test
seq:
  - id: my_array
    type: my_type
    repeat: expr
    repeat-expr: 2
types:
  my_type:
    seq:
      - id: foo
        type: u1
      - id: bar
        type: u1
```

Present behavior: clicking on one of the MyType instances in the tree clears the hex editor selection and does not select anything.
![image](https://user-images.githubusercontent.com/9056906/163902372-bc3fdf57-9036-4b37-aa81-c5a8b91fe2a4.png)

New behavior: clicking on one of the MyType instances in the tree selects the corresponding bytes in the hex editor.
![image](https://user-images.githubusercontent.com/9056906/163902407-12afd9ef-3b20-45d7-be66-6cb333af8a52.png)


Behavior not changed:
* Clicking on myArray in the tree selects the corresponding bytes in the hex editor. ![image](https://user-images.githubusercontent.com/9056906/163902247-3e8915a1-7a88-459a-a959-f5d2d37d259b.png)
* Clicking on one of the MyType fields in the tree selects the corresponding bytes in the hex editor.
![image](https://user-images.githubusercontent.com/9056906/163902295-c940be65-a56f-4889-a9a2-7eeecbb1831e.png)
